### PR TITLE
ValueError: invalid literal for int() with base 10: '>21301139'

### DIFF
--- a/GFF2MSS.py
+++ b/GFF2MSS.py
@@ -6,7 +6,7 @@
 # ======================================================================
 # Project Name    : GFF2MSS
 # File Name       : GFF2MSS.py
-# Version       : 4.0.3
+# Version       : 4.0.4
 # Encoding        : python
 # Creation Date   : 2019/08/30
 # Author : Taro Maeda 
@@ -384,8 +384,12 @@ def mRNA_MAKE_NP(gff_df_col, RNA_f, locus_tag_prefix, locus_tag_counter, anno_DF
     intron_sizes = []
     for end_start in POSITION.split('..'):
         if ',' in end_start:
-            end,start = end_start.split(',')
-            intron_size = int(start) - int(end) -1
+            end_val, start_val = end_start.split(',')
+            end_val_clean = end_val.strip('><')
+            start_val_clean = start_val.strip('><')
+            end_int = int(end_val_clean)
+            start_int = int(start_val_clean)
+            intron_size = start_int - end_int - 1
             intron_sizes.append(intron_size)
     intron_sizes = np.array(intron_sizes)
     OUT_CHA_tmp = CDS_CHA_SET(JOIN, locus_tag_prefix, locus_tag_counter, mRNA_ID, product_name, custom_locus_tag, 9, CODON_START)

--- a/GFF2MSS.py
+++ b/GFF2MSS.py
@@ -377,7 +377,11 @@ def mRNA_MAKE_NP(gff_df_col, RNA_f, locus_tag_prefix, locus_tag_counter, anno_DF
     if INCOMP5:
         POSITION = re.sub(r'^', '<', POSITION)
     if REVERSE_INCOMP5:
-        POSITION = re.sub(r'\.([^.]*$)', r'.>\1', POSITION)
+        new_position = re.sub(r'\.([^.]*$)', r'.>\1', POSITION)
+        if new_position == POSITION:
+            # If nothing changed, we likely have a single-coordinate end.
+            # So replace the very last coordinate with '>...'
+            new_position = re.sub(r'(\d+)([^,]*)$', r'>\1\2', POSITION)
         
     JOIN = out_STRAND + out_JOINT + POSITION + out_JOINT_CLOSE + out_STRAND_CLOSE
 


### PR DESCRIPTION
This is a bug fix for the error below. Extended ranges indicated by `>` or `<` interfered with subsequent operations of gene model coordinates.

```
Traceback (most recent call last):
  File "/Users/kf/Library/CloudStorage/GoogleDrive-kenji.fukushima@nig.ac.jp/My Drive/psnl/collaborators/Mitsuyasu_Hasebe/20241226_rotundifolia_gene_models/Drosera_rotundifoliaL1/output_files/../GFF2MSS/GFF2MSS.py", line 577, in <module>
    locus_tag_counter, OUT_CHA = GFF_TO_CDS(gff_df_col, in_file, NowContig, locus_tag_counter, anno_DF, pid_DF,
  File "/Users/kf/Library/CloudStorage/GoogleDrive-kenji.fukushima@nig.ac.jp/My Drive/psnl/collaborators/Mitsuyasu_Hasebe/20241226_rotundifolia_gene_models/Drosera_rotundifoliaL1/output_files/../GFF2MSS/GFF2MSS.py", line 498, in GFF_TO_CDS
    OUT_CHA = mRNA_MAKE_NP(gff_df_col_F, rec_sub, locus_tag_prefix, locus_tag_counter, anno_DF,
  File "/Users/kf/Library/CloudStorage/GoogleDrive-kenji.fukushima@nig.ac.jp/My Drive/psnl/collaborators/Mitsuyasu_Hasebe/20241226_rotundifolia_gene_models/Drosera_rotundifoliaL1/output_files/../GFF2MSS/GFF2MSS.py", line 388, in mRNA_MAKE_NP
    intron_size = int(start) - int(end) -1
ValueError: invalid literal for int() with base 10: '>21301139'
```